### PR TITLE
Increased expected number of documents

### DIFF
--- a/spec/hydrus_colls_spec.rb
+++ b/spec/hydrus_colls_spec.rb
@@ -83,7 +83,7 @@ describe "Hydrus collections" do
     it_behaves_like 'hydrus coll', 'ck552zg2217', 14, 'file', 'Book', nil, "open access to manuscripts", 'fx147cs4847', 10
   end
   context "GSE International Comparative Education Master's Monographs" do
-    it_behaves_like 'hydrus coll', 'qd259nz6640', 20, 'file', 'Book', nil, "conditions of happiness", 'xr366xd9204', 10 
+    it_behaves_like 'hydrus coll', 'qd259nz6640', 21, 'file', 'Book', nil, "conditions of happiness", 'xr366xd9204', 10 
   end
   context "GSE Open Archive" do
     it_behaves_like 'hydrus coll', 'tz959sb6952', 117, 'file', ["Book", 'Archive/Manuscript'], nil, "acculturative stress and coping", 'yg867nn1610', 5
@@ -193,7 +193,7 @@ describe "Hydrus collections" do
     it_behaves_like 'hydrus coll', 'dm482qr7820', 1, 'file', 'Software/Multimedia', nil, "decomposition package for stata", 'gw696hj6227', 10
   end
   context "Stanford Research Data" do
-    it_behaves_like 'hydrus coll', 'md919gh6774', 24, 'file', ['Dataset', 'Book', 'Video', 'Software/Multimedia'], nil, "high angular resolution", 'yx282xq2090', 3
+    it_behaves_like 'hydrus coll', 'md919gh6774', 26, 'file', ['Dataset', 'Book', 'Video', 'Software/Multimedia'], nil, "high angular resolution", 'yx282xq2090', 3
   end
   context "Stanford Student Letters and Memoirs" do
     it_behaves_like 'hydrus coll', 'mt423yd8582', 1, "file", "Archive/Manuscript", 'jv222bg0652',  "letters and memoirs", 'jv222bg0652', 10


### PR DESCRIPTION
Hydrus collections GSE International Comparative Education Master's Monographs behaves like hydrus coll behaves like all items in collection should be the expected number
     Failure/Error: resp.should have_exactly(num_exp).documents
       expected 20 documents, got 21
     Shared Example Group: "all items in collection" called from ./spec/hydrus_colls_spec.rb:29
     # ./spec/support/shared_examples.rb:177:in `block (2 levels) in <top (required)>'

Hydrus collections Stanford Research Data behaves like hydrus coll behaves like all items in collection should be the expected number
     Failure/Error: resp.should have_exactly(num_exp).documents
       expected 24 documents, got 26
     Shared Example Group: "all items in collection" called from ./spec/hydrus_colls_spec.rb:29
     # ./spec/support/shared_examples.rb:177:in `block (2 levels) in <top (required)>'