### PR TITLE
Fixed failures by increasing expected number of collections and items in collections

### DIFF
--- a/spec/all_gdor_records_spec.rb
+++ b/spec/all_gdor_records_spec.rb
@@ -4,7 +4,7 @@ describe "All GDOR records" do
 
   it "should have the correct number of digital collections" do
     resp = solr_resp_doc_ids_only({'fq'=> "collection_type:\"Digital Collection\""})
-    resp.should have_exactly(88).documents
+    resp.should have_exactly(90).documents
   end
 
   it "every non-collection object should have a collection" do

--- a/spec/hydrus_colls_spec.rb
+++ b/spec/hydrus_colls_spec.rb
@@ -53,7 +53,7 @@ describe "Hydrus collections" do
     it_behaves_like 'hydrus coll', 'hn807kb3349', 3, 'file', ["Book", "Archive/Manuscript"], nil, "chuck audio programming", 'jv545yc8727', 10
   end
   context "CISAC honors theses" do
-    it_behaves_like 'hydrus coll', 'md903dt5665', 13, 'file', 'Book', nil, "anarchy or regulation", 'zs241cm7504', 10
+    it_behaves_like 'hydrus coll', 'md903dt5665', 30, 'file', 'Book', nil, "anarchy or regulation", 'zs241cm7504', 10
   end
   context "City Nature" do
     it_behaves_like 'hydrus coll', 'zh869cy6686', 3, 'file', ['Book', 'Dataset'], nil, "naturehoods describing urban nature", 'yj038bt1548', 10
@@ -74,7 +74,7 @@ describe "Hydrus collections" do
     it_behaves_like 'hydrus coll', 'xv924ks7647', 3, 'file', 'Book', nil, "deduceit", 'bg823wn2892', 3
   end
   context "Engineering undergrad theses" do
-    it_behaves_like 'hydrus coll', 'jg722zc0626', 36, 'file', 'Book', nil, "uclinux", 'ng517gq2855', 3
+    it_behaves_like 'hydrus coll', 'jg722zc0626', 41, 'file', 'Book', nil, "uclinux", 'ng517gq2855', 3
   end
   context "Folding@home" do
     it_behaves_like 'hydrus coll', 'cj269gn0736', 8, 'file', 'Dataset', nil, "hp35 trajectory data", 'bd829sf1034', 3
@@ -223,7 +223,7 @@ describe "Hydrus collections" do
     it_behaves_like 'hydrus coll', 'sn758bh0099', 4, "file", "Book", nil, "dialectical critique of transgression", 'tp540zr1609', 10
   end
   context "Undergraduate Honors Theses, Graduate School of Education" do
-    it_behaves_like 'hydrus coll', 'qs035dj7859', 10, "file", "Book", nil, "Civic Engagement in Anakbayan", 'jw598xm2819', 3
+    it_behaves_like 'hydrus coll', 'qs035dj7859', 16, "file", "Book", nil, "Civic Engagement in Anakbayan", 'jw598xm2819', 3
   end
   context "Undergraduate Theses, Department of Biology, 2013-2014" do
     it_behaves_like 'hydrus coll', 'fr625dm6043', 49, "file", "Book", nil, "Ablation of Quiescent Neural Stem Cells", 'dz807gb9398', 5


### PR DESCRIPTION
1) All GDOR records should have the correct number of digital collections
     Failure/Error: resp.should have_exactly(88).documents
       expected 88 documents, got 90
     # ./spec/all_gdor_records_spec.rb:7:in `block (2 levels) in <top (required)>'

  2) Hydrus collections CISAC honors theses behaves like hydrus coll behaves like all items in collection should be the expected number
     Failure/Error: resp.should have_exactly(num_exp).documents
       expected 13 documents, got 30
     Shared Example Group: "all items in collection" called from ./spec/hydrus_colls_spec.rb:29
     # ./spec/support/shared_examples.rb:177:in `block (2 levels) in <top (required)>'

  3) Hydrus collections Engineering undergrad theses behaves like hydrus coll behaves like all items in collection should be the expected number
     Failure/Error: resp.should have_exactly(num_exp).documents
       expected 36 documents, got 41
     Shared Example Group: "all items in collection" called from ./spec/hydrus_colls_spec.rb:29
     # ./spec/support/shared_examples.rb:177:in `block (2 levels) in <top (required)>'

  5) Hydrus collections Undergraduate Honors Theses, Graduate School of Education behaves like hydrus coll behaves like all items in collection should be the expected number
     Failure/Error: resp.should have_exactly(num_exp).documents
       expected 10 documents, got 16
     Shared Example Group: "all items in collection" called from ./spec/hydrus_colls_spec.rb:29
     # ./spec/support/shared_examples.rb:177:in `block (2 levels) in <top (required)>'